### PR TITLE
김신영 투두리스트 미션 제출합니다.

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,11 @@
     <header>
         <section class="top_container">
           <span class="logo">TODO LIST</span>
-          <span class="plus_span">+</span>
-          <button type="button" id="btnPlus"></button>
+          <div id="plus_button_wrapper">
+            
+            <button type="button" class="plus_button"><span class="plus_span">+</span></button>
+          </div>
+          
           
         </section>
 

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
     </section>
 
     <section id="schedule_list_container">
+      <ul></ul>
     </section>
   </main>
 </body>

--- a/index.html
+++ b/index.html
@@ -9,21 +9,21 @@
   
   <body>
     <header>
-        <span id="title">TODO LIST</span>
+        <span class="white_bold_text">TODO LIST</span>
         <button type="button" id="btnPlus">+</button>
         <section id="addScheduleContainer">
-            <label for="scheduleInput">새로운 일정</label>
+            <label for="scheduleInput" class="white_small_text">새로운 일정</label>
             <div id="scheduleTextAndButtonContainer">
               <input type="text" id="scheduleInput">
-              <button type="submit" class="btnAddOrCancel" id="addBtn">추가</button>
-              <button type="submit" class="btnAddOrCancel" id="cancelBtn">취소</button>
+              <button type="submit" class="btnAddOrCancel white_small_text" id="addBtn">추가</button>
+              <button type="submit" class="btnAddOrCancel white_small_text" id="cancelBtn">취소</button>
             </div>
         </section>
     </header>
     
     <main>
       <section id="no_schedule_container">
-          <span id="noScheduleMessage">남은 일정이 없어요</span>
+          <span id="no_schedule_message" class="no_schedule_span">남은 일정이 없어요</span>
       </section>
 
       <section id="schedule_container">

--- a/index.html
+++ b/index.html
@@ -11,20 +11,25 @@
     <header>
         <span id="title">TODO LIST</span>
         <button type="button" id="btnPlus">+</button>
+        <section id="addScheduleContainer">
+            <label for="scheduleInput">새로운 일정</label>
+            <div id="scheduleTextAndButtonContainer">
+              <input type="text" id="scheduleInput">
+              <button type="submit" class="btnAddOrCancel" id="addBtn">추가</button>
+              <button type="submit" class="btnAddOrCancel" id="cancelBtn">취소</button>
+            </div>
+        </section>
     </header>
+    
+    <main>
+      <section id="no_schedule_container">
+          <span id="noScheduleMessage">남은 일정이 없어요</span>
+      </section>
 
-    <div id="addScheduleContainer">
-      <label for="scheduleInput">새로운 일정</label>
-      <div id="scheduleTextAndButtonContainer">
-        <input type="text" id="scheduleInput">
-        <button type="submit" class="btnAddOrCancel" id="addBtn">추가</button>
-        <button type="submit" class="btnAddOrCancel" id="cancelBtn">취소</button>
-      </div>
-    </div>
-
-    <div id="container">
-      <span id="noScheduleMessage">남은 일정이 없어요</span>
-    </div>
+      <section id="schedule_container">
+        
+      </section>
+    </main>
   </body>
 
   <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -1,44 +1,42 @@
 <!DOCTYPE html>
 <html lang="ko">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>To Do List</title>
-    <link rel="stylesheet" href="style.css">
-  </head>
-  
-  <body>
-    <header>
-        <section class="top_container">
-          <span class="logo">TODO LIST</span>
-          
-            <button type="button" id="plus_button"><span class="plus_span">+</span></button>
-          
-        </section>
 
-        <section id="new_schedule_input_container">
-            <label for="new_schedule_input" class="new_schedule_input_label"><span>새로운 일정</span></label>
-            <div class="input_and_buttons_container">
-              <input type="text" id="new_schedule_input">
-              <div class="new_schedule_input_button_container">
-                <button type="submit" class="new_schedule_input_button" id="add_input_button"><span>추가</span></button>
-                <button type="submit" class="new_schedule_input_button" id="cancel_input_button"><span>취소</span></button>
-              </div>
-            </div>
-        </section>
-    </header>
-    
-    <main>
-      <section id="no_schedule_container">
-          <span class="no_schedule_span">남은 일정이 없어요</span>
-      </section>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>To Do List</title>
+  <link rel="stylesheet" href="style.css">
+</head>
 
-      <section id="schedule_list_container">
-        
-      </section>
-    </main>
-  </body>
+<body>
+  <header>
+    <section class="top_container">
+      <span class="logo">TODO LIST</span>
+      <button type="button" id="plus_button"><span class="plus_span">+</span></button>
+    </section>
 
-  <script src="script.js"></script>
+    <section id="new_schedule_input_container">
+      <label for="new_schedule_input" class="new_schedule_input_label"><span>새로운 일정</span></label>
+      <div class="input_and_buttons_container">
+        <input type="text" id="new_schedule_input">
+        <div class="new_schedule_input_button_container">
+          <button type="submit" class="new_schedule_input_button" id="add_input_button"><span>추가</span></button>
+          <button type="submit" class="new_schedule_input_button" id="cancel_input_button"><span>취소</span></button>
+        </div>
+      </div>
+    </section>
+  </header>
+
+  <main>
+    <section id="no_schedule_container">
+      <span class="no_schedule_span">남은 일정이 없어요</span>
+    </section>
+
+    <section id="schedule_list_container">
+    </section>
+  </main>
+</body>
+
+<script src="script.js"></script>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -2,10 +2,31 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>To Do List</title>
+    <link rel="stylesheet" href="style.css">
   </head>
-
+  
   <body>
-    <header>TODO LIST</header>
+    <header>
+        <span id="title">TODO LIST</span>
+        <button id="btnPlus">+</button>
+    </header>
+
+    <div id="addScheduleContainer">
+      <span id="addTitle">새로운 일정</span>
+      <div id="scheduleTextAndButtonContainer">
+        <input type="text" id="scheduleInput">
+        <button class="btnAddOrCancel" id="addBtn">추가</button>
+        <button class="btnAddOrCancel" id="cancelBtn">취소</button>
+      </div>
+    </div>
+
+    <div id="container">
+      <span id="noScheduleMessage">남은 일정이 없어요</span>
+    </div>
   </body>
+
+  <script src="script.js"></script>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     </header>
 
     <div id="addScheduleContainer">
-      <span id="addTitle">새로운 일정</span>
+      <label for="scheduleInput">새로운 일정</label>
       <div id="scheduleTextAndButtonContainer">
         <input type="text" id="scheduleInput">
         <button class="btnAddOrCancel" id="addBtn">추가</button>

--- a/index.html
+++ b/index.html
@@ -12,19 +12,18 @@
         <section class="top_container">
           <span class="logo">TODO LIST</span>
           <div id="plus_button_wrapper">
-            
             <button type="button" class="plus_button"><span class="plus_span">+</span></button>
           </div>
-          
-          
         </section>
 
-        <section id="addScheduleContainer">
-            <label for="scheduleInput" class="new_schedule_input_label"><span>새로운 일정</span></label>
-            <div id="scheduleTextAndButtonContainer">
-              <input type="text" id="scheduleInput">
-              <button type="submit" class="btnAddOrCancel" id="addBtn"><span>추가</span></button>
-              <button type="submit" class="btnAddOrCancel" id="cancelBtn"><span>취소</span></button>
+        <section id="new_schedule_input_container">
+            <label for="new_schedule_input" class="new_schedule_input_label"><span>새로운 일정</span></label>
+            <div class="input_and_buttons_container">
+              <input type="text" id="new_schedule_input">
+              <div class="new_schedule_input_button_container">
+                <button type="submit" class="new_schedule_input_button" id="add_input_button"><span>추가</span></button>
+                <button type="submit" class="new_schedule_input_button" id="cancel_input_button"><span>취소</span></button>
+              </div>
             </div>
         </section>
     </header>

--- a/index.html
+++ b/index.html
@@ -9,11 +9,13 @@
   
   <body>
     <header>
-        <span class="logo white_text">TODO LIST</span>
-        <button type="button" id="btnPlus">
-          <div class="plus_button"></div>
+        <section class="top_container">
+          <span class="logo white_text">TODO LIST</span>
           <span class="white_text plus_span">+</span>
-        </button>
+          <button type="button" id="btnPlus"></button>
+          
+        </section>
+
         <section id="addScheduleContainer">
             <label for="scheduleInput" class="white_text new_schedule_input_label">새로운 일정</label>
             <div id="scheduleTextAndButtonContainer">

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
           <span class="no_schedule_span">남은 일정이 없어요</span>
       </section>
 
-      <section id="schedule_container">
+      <section id="schedule_list_container">
         
       </section>
     </main>

--- a/index.html
+++ b/index.html
@@ -9,14 +9,17 @@
   
   <body>
     <header>
-        <span class="white_bold_text">TODO LIST</span>
-        <button type="button" id="btnPlus">+</button>
+        <span class="logo white_text">TODO LIST</span>
+        <button type="button" id="btnPlus">
+          <div class="plus_button"></div>
+          <span class="white_text plus_span">+</span>
+        </button>
         <section id="addScheduleContainer">
-            <label for="scheduleInput" class="white_small_text">새로운 일정</label>
+            <label for="scheduleInput" class="white_text new_schedule_input_label">새로운 일정</label>
             <div id="scheduleTextAndButtonContainer">
               <input type="text" id="scheduleInput">
-              <button type="submit" class="btnAddOrCancel white_small_text" id="addBtn">추가</button>
-              <button type="submit" class="btnAddOrCancel white_small_text" id="cancelBtn">취소</button>
+              <button type="submit" class="btnAddOrCancel white_text" id="addBtn">추가</button>
+              <button type="submit" class="btnAddOrCancel white_text" id="cancelBtn">취소</button>
             </div>
         </section>
     </header>

--- a/index.html
+++ b/index.html
@@ -10,25 +10,25 @@
   <body>
     <header>
         <section class="top_container">
-          <span class="logo white_text">TODO LIST</span>
-          <span class="white_text plus_span">+</span>
+          <span class="logo">TODO LIST</span>
+          <span class="plus_span">+</span>
           <button type="button" id="btnPlus"></button>
           
         </section>
 
         <section id="addScheduleContainer">
-            <label for="scheduleInput" class="white_text new_schedule_input_label">새로운 일정</label>
+            <label for="scheduleInput" class="new_schedule_input_label"><span>새로운 일정</span></label>
             <div id="scheduleTextAndButtonContainer">
               <input type="text" id="scheduleInput">
-              <button type="submit" class="btnAddOrCancel white_text" id="addBtn">추가</button>
-              <button type="submit" class="btnAddOrCancel white_text" id="cancelBtn">취소</button>
+              <button type="submit" class="btnAddOrCancel" id="addBtn"><span>추가</span></button>
+              <button type="submit" class="btnAddOrCancel" id="cancelBtn"><span>취소</span></button>
             </div>
         </section>
     </header>
     
     <main>
       <section id="no_schedule_container">
-          <span id="no_schedule_message" class="no_schedule_span">남은 일정이 없어요</span>
+          <span class="no_schedule_span">남은 일정이 없어요</span>
       </section>
 
       <section id="schedule_container">

--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
     <header>
         <section class="top_container">
           <span class="logo">TODO LIST</span>
-          <div id="plus_button_wrapper">
-            <button type="button" class="plus_button"><span class="plus_span">+</span></button>
-          </div>
+          
+            <button type="button" id="plus_button"><span class="plus_span">+</span></button>
+          
         </section>
 
         <section id="new_schedule_input_container">

--- a/index.html
+++ b/index.html
@@ -10,15 +10,15 @@
   <body>
     <header>
         <span id="title">TODO LIST</span>
-        <button id="btnPlus">+</button>
+        <button type="button" id="btnPlus">+</button>
     </header>
 
     <div id="addScheduleContainer">
       <label for="scheduleInput">새로운 일정</label>
       <div id="scheduleTextAndButtonContainer">
         <input type="text" id="scheduleInput">
-        <button class="btnAddOrCancel" id="addBtn">추가</button>
-        <button class="btnAddOrCancel" id="cancelBtn">취소</button>
+        <button type="submit" class="btnAddOrCancel" id="addBtn">추가</button>
+        <button type="submit" class="btnAddOrCancel" id="cancelBtn">취소</button>
       </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@ const PLUS_BUTTON = 0;
 const ADD_SCHEDULE_CONTAINER = 1;
 const NO_SCHEDULE_MESSAGE = 2;
 
-const btnPlus = document.getElementById("btnPlus");
+const plusButtonWrapper = document.getElementById("plus_button_wrapper");
 const addScheduleContainer = document.getElementById("addScheduleContainer");
 const addBtn = document.getElementById("addBtn");
 const cancelBtn = document.getElementById("cancelBtn");
@@ -16,7 +16,7 @@ let scheduleArray = [];
 function showContents(content) {
     switch (content) {
         case PLUS_BUTTON:
-            btnPlus.style.display = 'inline';
+            plusButtonWrapper.style.display = 'inline';
             break;
 
         case ADD_SCHEDULE_CONTAINER:
@@ -36,7 +36,7 @@ function hideContents(content) {
 
     switch (content) {
         case PLUS_BUTTON:
-            target = btnPlus;
+            target = plusButtonWrapper;
             break;
 
         case ADD_SCHEDULE_CONTAINER:
@@ -114,7 +114,7 @@ function searchSchedule(addedScheduleName) {
     return false;
 }
 
-btnPlus.addEventListener("click", function () {
+plusButtonWrapper.addEventListener("click", function () {
     showContents(ADD_SCHEDULE_CONTAINER);
     hideContents(PLUS_BUTTON);
 });

--- a/script.js
+++ b/script.js
@@ -11,7 +11,7 @@ const container = document.getElementById("container");
 const noScheduleMessage = document.getElementById("noScheduleMessage");
 const schedulesContainer = document.getElementById("schedulesContainer");
 
-let scheduleArray = [];
+const scheduleArray = [];
 
 function showContents(content) {
     switch (content) {

--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ const cancelInputButton = document.getElementById("cancel_input_button");
 const newScheduleInput = document.getElementById("new_schedule_input");
 const noScheduleContainer = document.getElementById("no_schedule_container");
 const scheduleListContainer = document.getElementById("schedule_list_container");
+const ul = document.querySelector("ul");
 
 let scheduleArray = [];
 let isScheduleExist;
@@ -47,27 +48,17 @@ function addSchedule(addedScheduleName) {
 }
 
 function addScheduleUI(addedScheduleName) {
-    const scheduleContainer = document.createElement('div');
+    const scheduleContainer = document.createElement('li');
     const scheduleName = document.createElement('span');
     const scheduleDeleteButton = document.createElement('button');
 
     scheduleName.innerText = addedScheduleName;
-    scheduleDeleteButton.innerText = "x";
-    scheduleDeleteButton.style.border = "none";
-    scheduleDeleteButton.style.backgroundColor = "transparent";
     scheduleContainer.id = addedScheduleName;
-    scheduleName.style.color = "#000000";
-    scheduleDeleteButton.style.color = "#000000";
-
-    scheduleContainer.style.width = "100vw";
-    scheduleContainer.style.padding = "24px 17px 24px 11px";
-    scheduleContainer.style.borderBottom = "1px solid #DEDEDE";
-    scheduleContainer.style.boxSizing = "border-box";
-    scheduleDeleteButton.style.float = "right";
+    scheduleDeleteButton.innerText = "x";
 
     scheduleContainer.appendChild(scheduleName);
     scheduleContainer.appendChild(scheduleDeleteButton);
-    scheduleListContainer.appendChild(scheduleContainer);
+    ul.appendChild(scheduleContainer);
 
     scheduleDeleteButton.addEventListener("click", function () {
         scheduleArray = scheduleArray.filter((schedule) => schedule !== addedScheduleName);

--- a/script.js
+++ b/script.js
@@ -2,29 +2,24 @@ const PLUS_BUTTON = 0;
 const ADD_SCHEDULE_CONTAINER = 1;
 const NO_SCHEDULE_MESSAGE = 2;
 
-const plusButtonWrapper = document.getElementById("plus_button_wrapper");
-const addScheduleContainer = document.getElementById("addScheduleContainer");
-const addBtn = document.getElementById("addBtn");
-const cancelBtn = document.getElementById("cancelBtn");
-const scheduleInput = document.getElementById("scheduleInput");
-const container = document.getElementById("container");
-const noScheduleMessage = document.getElementById("noScheduleMessage");
-const schedulesContainer = document.getElementById("schedulesContainer");
+const plusButton = document.getElementById("plus_button");
+const newScheduleInputContainer = document.getElementById("new_schedule_input_container");
+const addInputButton = document.getElementById("add_input_button");
+const cancelInputButton = document.getElementById("cancel_input_button");
+const newScheduleInput = document.getElementById("new_schedule_input");
+const noScheduleContainer = document.getElementById("no_schedule_container");
+const scheduleListContainer = document.getElementById("schedule_list_container");
 
 const scheduleArray = [];
 
 function showContents(content) {
     switch (content) {
         case PLUS_BUTTON:
-            plusButtonWrapper.style.display = 'inline';
+            plusButton.style.display = 'inline';
             break;
 
         case ADD_SCHEDULE_CONTAINER:
-            addScheduleContainer.style.display = 'block';
-            break;
-
-        case NO_SCHEDULE_MESSAGE:
-            noScheduleMessage.style.display = 'block';
+            newScheduleInputContainer.style.display = 'block';
             break;
 
         // no default
@@ -36,15 +31,11 @@ function hideContents(content) {
 
     switch (content) {
         case PLUS_BUTTON:
-            target = plusButtonWrapper;
+            target = plusButton;
             break;
 
         case ADD_SCHEDULE_CONTAINER:
-            target = addScheduleContainer;
-            break;
-
-        case NO_SCHEDULE_MESSAGE:
-            target = noScheduleMessage;
+            target = newScheduleInputContainer;
             break;
 
         // no default
@@ -55,15 +46,13 @@ function hideContents(content) {
 
 function changeContainerStyle() {
     if (scheduleArray.length > 0) {
-        container.style.flexDirection = "column"
-        container.style.alignItems = "flex-start";
-        container.style.justifyContent = "flex-start";
-        hideContents(NO_SCHEDULE_MESSAGE);
+        scheduleListContainer.style.display = 'flex';
+        scheduleListContainer.style.flex = 1;
+        noScheduleContainer.style.display = 'none';
     } else {
-        container.style.flexDirection = "row"
-        container.style.alignItems = "center";
-        container.style.justifyContent = "center";
-        showContents(NO_SCHEDULE_MESSAGE);
+        scheduleListContainer.style.display = 'none';
+        noScheduleContainer.style.display = 'flex';
+        noScheduleContainer.style.flex = 1;
     }
 }
 
@@ -80,6 +69,8 @@ function addScheduleUI(addedScheduleName) {
     scheduleName.innerText = addedScheduleName;
     scheduleDeleteButton.innerText = "x";
     scheduleContainer.id = addedScheduleName;
+    scheduleName.style.color = "#000000";
+    scheduleDeleteButton.style.color = "#000000";
 
     scheduleContainer.style.width = "100vw";
     scheduleContainer.style.padding = "24px 17px 24px 11px";
@@ -89,7 +80,7 @@ function addScheduleUI(addedScheduleName) {
 
     scheduleContainer.appendChild(scheduleName);
     scheduleContainer.appendChild(scheduleDeleteButton);
-    container.appendChild(scheduleContainer);
+    scheduleListContainer.appendChild(scheduleContainer);
 
     scheduleDeleteButton.addEventListener("click", function () {
         for (var i = 0; i < scheduleArray.length; i++) {
@@ -114,15 +105,15 @@ function searchSchedule(addedScheduleName) {
     return false;
 }
 
-plusButtonWrapper.addEventListener("click", function () {
+plusButton.addEventListener("click", function () {
     showContents(ADD_SCHEDULE_CONTAINER);
     hideContents(PLUS_BUTTON);
 });
 
-addBtn.addEventListener("click", function () {
-    let addedScheduleName = scheduleInput.value;
+addInputButton.addEventListener("click", function () {
+    let addedScheduleName = newScheduleInput.value;
 
-    scheduleInput.value = null;
+    newScheduleInput.value = null;
 
     if (addedScheduleName.length === 0) {
         window.alert("스케줄 이름을 입력해주세요");
@@ -138,8 +129,8 @@ addBtn.addEventListener("click", function () {
     hideContents(ADD_SCHEDULE_CONTAINER);
 });
 
-cancelBtn.addEventListener("click", function () {
-    scheduleInput.value = null;
+cancelInputButton.addEventListener("click", function () {
+    newScheduleInput.value = null;
 
     showContents(PLUS_BUTTON);
     hideContents(ADD_SCHEDULE_CONTAINER);

--- a/script.js
+++ b/script.js
@@ -1,0 +1,146 @@
+const PLUS_BUTTON = 0;
+const ADD_SCHEDULE_CONTAINER = 1;
+const NO_SCHEDULE_MESSAGE = 2;
+
+const btnPlus = document.getElementById("btnPlus");
+const addScheduleContainer = document.getElementById("addScheduleContainer");
+const addBtn = document.getElementById("addBtn");
+const cancelBtn = document.getElementById("cancelBtn");
+const scheduleInput = document.getElementById("scheduleInput");
+const container = document.getElementById("container");
+const noScheduleMessage = document.getElementById("noScheduleMessage");
+const schedulesContainer = document.getElementById("schedulesContainer");
+
+let scheduleArray = [];
+
+function showContents(content) {
+    switch (content) {
+        case PLUS_BUTTON:
+            btnPlus.style.display = 'flex';
+            break;
+
+        case ADD_SCHEDULE_CONTAINER:
+            addScheduleContainer.style.display = 'block';
+            break;
+
+        case NO_SCHEDULE_MESSAGE:
+            noScheduleMessage.style.display = 'block';
+            break;
+
+        // no default
+    }
+}
+
+function hideContents(content) {
+    let target;
+
+    switch (content) {
+        case PLUS_BUTTON:
+            target = btnPlus;
+            break;
+
+        case ADD_SCHEDULE_CONTAINER:
+            target = addScheduleContainer;
+            break;
+
+        case NO_SCHEDULE_MESSAGE:
+            target = noScheduleMessage;
+            break;
+
+        // no default
+    }
+
+    target.style.display = "none";
+}
+
+function changeContainerStyle() {
+    if (scheduleArray.length > 0) {
+        container.style.flexDirection = "column"
+        container.style.alignItems = "flex-start";
+        container.style.justifyContent = "flex-start";
+        hideContents(NO_SCHEDULE_MESSAGE);
+    } else {
+        container.style.flexDirection = "row"
+        container.style.alignItems = "center";
+        container.style.justifyContent = "center";
+        showContents(NO_SCHEDULE_MESSAGE);
+    }
+}
+
+function addSchedule(addedScheduleName) {
+    scheduleArray.push(addedScheduleName);
+    addScheduleUI(addedScheduleName);
+}
+
+function addScheduleUI(addedScheduleName) {
+    const scheduleContainer = document.createElement('div');
+    const scheduleName = document.createElement('span');
+    const scheduleDeleteButton = document.createElement('span');
+
+    scheduleName.innerText = addedScheduleName;
+    scheduleDeleteButton.innerText = "x";
+    scheduleContainer.id = addedScheduleName;
+
+    scheduleContainer.style.width = "100vw";
+    scheduleContainer.style.padding = "24px 17px 24px 11px";
+    scheduleContainer.style.borderBottom = "1px solid #DEDEDE";
+    scheduleContainer.style.boxSizing = "border-box";
+    scheduleDeleteButton.style.float = "right";
+
+    scheduleContainer.appendChild(scheduleName);
+    scheduleContainer.appendChild(scheduleDeleteButton);
+    container.appendChild(scheduleContainer);
+
+    scheduleDeleteButton.addEventListener("click", function () {
+        for (var i = 0; i < scheduleArray.length; i++) {
+            if (scheduleArray[i] === addedScheduleName) {
+                scheduleArray.splice(i, 1);
+                return;
+            }
+        }
+
+        scheduleContainer.style.display = "none";
+        changeContainerStyle();
+    });
+}
+
+function searchSchedule(addedScheduleName) {
+    for (const schedule of scheduleArray) {
+        if (addedScheduleName === schedule) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+btnPlus.addEventListener("click", function () {
+    showContents(ADD_SCHEDULE_CONTAINER);
+    hideContents(PLUS_BUTTON);
+});
+
+addBtn.addEventListener("click", function () {
+    let addedScheduleName = scheduleInput.value;
+
+    scheduleInput.value = null;
+
+    if (addedScheduleName.length === 0) {
+        window.alert("스케줄 이름을 입력해주세요");
+        return;
+    } else if (searchSchedule(addedScheduleName)) {
+        window.alert("이미 존재하는 스케줄입니다");
+    } else {
+        addSchedule(addedScheduleName);
+        changeContainerStyle();
+    }
+
+    showContents(PLUS_BUTTON);
+    hideContents(ADD_SCHEDULE_CONTAINER);
+});
+
+cancelBtn.addEventListener("click", function () {
+    scheduleInput.value = null;
+
+    showContents(PLUS_BUTTON);
+    hideContents(ADD_SCHEDULE_CONTAINER);
+});

--- a/script.js
+++ b/script.js
@@ -6,8 +6,6 @@ const newScheduleInput = document.getElementById("new_schedule_input");
 const noScheduleContainer = document.getElementById("no_schedule_container");
 const scheduleListContainer = document.getElementById("schedule_list_container");
 const ul = document.querySelector("ul");
-const main = document.querySelector("main");
-const header = document.querySelector("header");
 
 let scheduleArray = [];
 let isScheduleExist;

--- a/script.js
+++ b/script.js
@@ -76,16 +76,6 @@ function addScheduleUI(addedScheduleName) {
     });
 }
 
-function searchSchedule(addedScheduleName) {
-    for (const schedule of scheduleArray) {
-        if (addedScheduleName === schedule) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 function clearNewScheduleInput() {
     newScheduleInput.value = null;
 }
@@ -101,7 +91,7 @@ addInputButton.addEventListener("click", function () {
     if (addedScheduleName.length === 0) {
         window.alert("스케줄 이름을 입력해주세요");
         return;
-    } else if (searchSchedule(addedScheduleName)) {
+    } else if (scheduleArray.some((schedule) => schedule === addedScheduleName)) {
         window.alert("이미 존재하는 스케줄입니다");
     } else {
         addSchedule(addedScheduleName);

--- a/script.js
+++ b/script.js
@@ -16,7 +16,7 @@ let scheduleArray = [];
 function showContents(content) {
     switch (content) {
         case PLUS_BUTTON:
-            btnPlus.style.display = 'flex';
+            btnPlus.style.display = 'inline';
             break;
 
         case ADD_SCHEDULE_CONTAINER:

--- a/script.js
+++ b/script.js
@@ -64,10 +64,12 @@ function addSchedule(addedScheduleName) {
 function addScheduleUI(addedScheduleName) {
     const scheduleContainer = document.createElement('div');
     const scheduleName = document.createElement('span');
-    const scheduleDeleteButton = document.createElement('span');
+    const scheduleDeleteButton = document.createElement('button');
 
     scheduleName.innerText = addedScheduleName;
     scheduleDeleteButton.innerText = "x";
+    scheduleDeleteButton.style.border = "none";
+    scheduleDeleteButton.style.backgroundColor = "transparent";
     scheduleContainer.id = addedScheduleName;
     scheduleName.style.color = "#000000";
     scheduleDeleteButton.style.color = "#000000";
@@ -86,7 +88,6 @@ function addScheduleUI(addedScheduleName) {
         for (var i = 0; i < scheduleArray.length; i++) {
             if (scheduleArray[i] === addedScheduleName) {
                 scheduleArray.splice(i, 1);
-                return;
             }
         }
 

--- a/script.js
+++ b/script.js
@@ -1,7 +1,3 @@
-const PLUS_BUTTON = 0;
-const ADD_SCHEDULE_CONTAINER = 1;
-const NO_SCHEDULE_MESSAGE = 2;
-
 const plusButton = document.getElementById("plus_button");
 const newScheduleInputContainer = document.getElementById("new_schedule_input_container");
 const addInputButton = document.getElementById("add_input_button");
@@ -11,6 +7,7 @@ const noScheduleContainer = document.getElementById("no_schedule_container");
 const scheduleListContainer = document.getElementById("schedule_list_container");
 
 const scheduleArray = [];
+let isScheduleExist;
 
 function requireNewScheduleInputContainer() {
     newScheduleInputContainer.style.display = 'block';
@@ -23,7 +20,9 @@ function revertNewScheduleInputContainer() {
 }
 
 function changeContainerStyle() {
-    if (scheduleArray.length > 0) {
+    isScheduleExist = (scheduleArray.length > 0);
+
+    if (isScheduleExist) {
         scheduleListContainer.style.display = 'flex';
         scheduleListContainer.style.flex = 1;
         noScheduleContainer.style.display = 'none';

--- a/script.js
+++ b/script.js
@@ -9,7 +9,7 @@ const scheduleListContainer = document.getElementById("schedule_list_container")
 let scheduleArray = [];
 let isScheduleExist;
 
-function requireNewScheduleInputContainer() {
+function demandNewScheduleInputContainer() {
     newScheduleInputContainer.style.display = 'block';
     plusButton.style.display = "none";
 }
@@ -19,17 +19,25 @@ function revertNewScheduleInputContainer() {
     plusButton.style.display = 'inline';
 }
 
+function demandScheduleListContainer() {
+    scheduleListContainer.style.display = 'flex';
+    scheduleListContainer.style.flex = 1;
+    noScheduleContainer.style.display = 'none';
+}
+
+function demandNoScheduleListContainer() {
+    noScheduleContainer.style.display = 'flex';
+    noScheduleContainer.style.flex = 1;
+    scheduleListContainer.style.display = 'none';
+}
+
 function changeContainerStyle() {
     isScheduleExist = (scheduleArray.length > 0);
 
     if (isScheduleExist) {
-        scheduleListContainer.style.display = 'flex';
-        scheduleListContainer.style.flex = 1;
-        noScheduleContainer.style.display = 'none';
+        demandScheduleListContainer();
     } else {
-        scheduleListContainer.style.display = 'none';
-        noScheduleContainer.style.display = 'flex';
-        noScheduleContainer.style.flex = 1;
+        demandNoScheduleListContainer();
     }
 }
 
@@ -79,7 +87,7 @@ function searchSchedule(addedScheduleName) {
 }
 
 plusButton.addEventListener("click", function () {
-    requireNewScheduleInputContainer();
+    demandNewScheduleInputContainer();
 });
 
 addInputButton.addEventListener("click", function () {

--- a/script.js
+++ b/script.js
@@ -68,7 +68,7 @@ function addScheduleUI(addedScheduleName) {
             }
         }
 
-        scheduleContainer.style.display = "none";
+        scheduleContainer.remove();
         changeContainerStyle();
     });
 }

--- a/script.js
+++ b/script.js
@@ -6,7 +6,7 @@ const newScheduleInput = document.getElementById("new_schedule_input");
 const noScheduleContainer = document.getElementById("no_schedule_container");
 const scheduleListContainer = document.getElementById("schedule_list_container");
 
-const scheduleArray = [];
+let scheduleArray = [];
 let isScheduleExist;
 
 function requireNewScheduleInputContainer() {
@@ -62,12 +62,7 @@ function addScheduleUI(addedScheduleName) {
     scheduleListContainer.appendChild(scheduleContainer);
 
     scheduleDeleteButton.addEventListener("click", function () {
-        for (var i = 0; i < scheduleArray.length; i++) {
-            if (scheduleArray[i] === addedScheduleName) {
-                scheduleArray.splice(i, 1);
-            }
-        }
-
+        scheduleArray = scheduleArray.filter((schedule) => schedule !== addedScheduleName);
         scheduleContainer.remove();
         changeContainerStyle();
     });

--- a/script.js
+++ b/script.js
@@ -1,3 +1,6 @@
+const PADDING_WITH_SCROLL = "34px";
+const PADDING_WITH_NO_SCROLL = "17px";
+
 const plusButton = document.getElementById("plus_button");
 const newScheduleInputContainer = document.getElementById("new_schedule_input_container");
 const addInputButton = document.getElementById("add_input_button");
@@ -15,11 +18,11 @@ function checkScroll() {
 
     if (scheduleListContainer.scrollHeight > scheduleListContainer.clientHeight) {
         Array.from(lis).forEach(li => {
-            li.style.paddingRight = "34px";
+            li.style.paddingRight = PADDING_WITH_SCROLL;
         });
     } else {
         Array.from(lis).forEach(li => {
-            li.style.paddingRight = "17px";
+            li.style.paddingRight = PADDING_WITH_NO_SCROLL;
         });
     }
 }

--- a/script.js
+++ b/script.js
@@ -6,18 +6,36 @@ const newScheduleInput = document.getElementById("new_schedule_input");
 const noScheduleContainer = document.getElementById("no_schedule_container");
 const scheduleListContainer = document.getElementById("schedule_list_container");
 const ul = document.querySelector("ul");
+const main = document.querySelector("main");
+const header = document.querySelector("header");
 
 let scheduleArray = [];
 let isScheduleExist;
 
+function checkScroll() {
+    const lis = document.getElementsByTagName("Li");
+
+    if (scheduleListContainer.scrollHeight > scheduleListContainer.clientHeight) {
+        Array.from(lis).forEach(li => {
+            li.style.paddingRight = "34px";
+        });
+    } else {
+        Array.from(lis).forEach(li => {
+            li.style.paddingRight = "17px";
+        });
+    }
+}
+
 function demandNewScheduleInputContainer() {
     newScheduleInputContainer.style.display = 'block';
     plusButton.style.display = "none";
+    checkScroll();
 }
 
 function revertNewScheduleInputContainer() {
     newScheduleInputContainer.style.display = "none";
     plusButton.style.display = 'inline';
+    checkScroll();
 }
 
 function demandScheduleListContainer() {
@@ -60,10 +78,13 @@ function addScheduleUI(addedScheduleName) {
     scheduleContainer.appendChild(scheduleDeleteButton);
     ul.appendChild(scheduleContainer);
 
+    checkScroll();
+
     scheduleDeleteButton.addEventListener("click", function () {
         scheduleArray = scheduleArray.filter((schedule) => schedule !== addedScheduleName);
         scheduleContainer.remove();
         changeContainerStyle();
+        checkScroll();
     });
 }
 

--- a/script.js
+++ b/script.js
@@ -86,14 +86,17 @@ function searchSchedule(addedScheduleName) {
     return false;
 }
 
+function clearNewScheduleInput() {
+    newScheduleInput.value = null;
+}
+
 plusButton.addEventListener("click", function () {
     demandNewScheduleInputContainer();
 });
 
 addInputButton.addEventListener("click", function () {
     let addedScheduleName = newScheduleInput.value;
-
-    newScheduleInput.value = null;
+    clearNewScheduleInput();
 
     if (addedScheduleName.length === 0) {
         window.alert("스케줄 이름을 입력해주세요");
@@ -109,6 +112,6 @@ addInputButton.addEventListener("click", function () {
 });
 
 cancelInputButton.addEventListener("click", function () {
-    newScheduleInput.value = null;
+    clearNewScheduleInput();
     revertNewScheduleInputContainer();
 });

--- a/script.js
+++ b/script.js
@@ -12,36 +12,14 @@ const scheduleListContainer = document.getElementById("schedule_list_container")
 
 const scheduleArray = [];
 
-function showContents(content) {
-    switch (content) {
-        case PLUS_BUTTON:
-            plusButton.style.display = 'inline';
-            break;
-
-        case ADD_SCHEDULE_CONTAINER:
-            newScheduleInputContainer.style.display = 'block';
-            break;
-
-        // no default
-    }
+function requireNewScheduleInputContainer() {
+    newScheduleInputContainer.style.display = 'block';
+    plusButton.style.display = "none";
 }
 
-function hideContents(content) {
-    let target;
-
-    switch (content) {
-        case PLUS_BUTTON:
-            target = plusButton;
-            break;
-
-        case ADD_SCHEDULE_CONTAINER:
-            target = newScheduleInputContainer;
-            break;
-
-        // no default
-    }
-
-    target.style.display = "none";
+function revertNewScheduleInputContainer() {
+    newScheduleInputContainer.style.display = "none";
+    plusButton.style.display = 'inline';
 }
 
 function changeContainerStyle() {
@@ -107,8 +85,7 @@ function searchSchedule(addedScheduleName) {
 }
 
 plusButton.addEventListener("click", function () {
-    showContents(ADD_SCHEDULE_CONTAINER);
-    hideContents(PLUS_BUTTON);
+    requireNewScheduleInputContainer();
 });
 
 addInputButton.addEventListener("click", function () {
@@ -126,13 +103,10 @@ addInputButton.addEventListener("click", function () {
         changeContainerStyle();
     }
 
-    showContents(PLUS_BUTTON);
-    hideContents(ADD_SCHEDULE_CONTAINER);
+    revertNewScheduleInputContainer();
 });
 
 cancelInputButton.addEventListener("click", function () {
     newScheduleInput.value = null;
-
-    showContents(PLUS_BUTTON);
-    hideContents(ADD_SCHEDULE_CONTAINER);
+    revertNewScheduleInputContainer();
 });

--- a/style.css
+++ b/style.css
@@ -22,6 +22,10 @@ span {
     color: #FFFFFF;
 }
 
+button {
+    cursor: pointer;
+}
+
 .top_container {
     width: 100%;
     max-height: 46px;

--- a/style.css
+++ b/style.css
@@ -3,7 +3,6 @@ body {
     height: 100vh;
     display: flex;
     flex-direction: column;
-    overflow-x: hidden;
 }
 
 header {
@@ -107,6 +106,7 @@ span {
 main {
     flex: 1;
     display: flex;
+    height: calc(100vh - 46px - 75px);
 }
 
 #no_schedule_container {
@@ -121,6 +121,8 @@ main {
     display: flex;
     justify-content: flex-start;
     flex-direction: column;
+    overflow: auto;
+    overflow-x: hidden;
 }
 
 .no_schedule_span {

--- a/style.css
+++ b/style.css
@@ -72,8 +72,7 @@ span {
     background: #2C2C2C;
 }
 
-#addTitle {
-    display: block;
+label {
     padding: 4px 0px 0px 11px;
 
     font-family: 'Inter';

--- a/style.css
+++ b/style.css
@@ -10,18 +10,10 @@ header {
     width: 100vw;
     min-height: 46px;
     box-sizing: border-box;
-    /* padding: 9px 15px 8px 11px; */
     background: #2C2C2C;
     display: flex;
     justify-content: space-between;
     flex-direction: column;
-}
-
-#container {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
 }
 
 span {
@@ -31,15 +23,18 @@ span {
     color: #FFFFFF;
 }
 
+.top_container {
+    width: 100%;
+    max-height: 46px;
+    display: block;
+}
+
 .logo {
     display: inline-block;
     font-weight: 700;
     font-size: 24px;
     line-height: 29px;
     height: calc(100% - 18px);
-}
-
-.logo {
     margin: 9px 15px;
 }
 
@@ -52,23 +47,10 @@ span {
     right: 12px;
 }
 
-.top_container {
-    width: 100%;
-    max-height: 46px;
-    display: block;
-}
-
-.new_schedule_input_label, .btnAddOrCancel {
-    font-weight: 500;
-    font-size: 16px;
-    line-height: 19px;
-}
-
 .plus_button {
     width: 27px;
     height: 27px;
     border: 1px solid #FFFFFF;
-    /* float: right; */
     border-radius: 50%;
     background-color: transparent;
     position: fixed;
@@ -76,49 +58,52 @@ span {
     right: 11px;
 }
 
-#addScheduleContainer {
+#new_schedule_input_container {
     width: 100%;
     height: 75px;
     display: none;
     background: #2C2C2C;
 }
 
-label {
+.new_schedule_input_label, .new_schedule_input_button {
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 19px;
+}
+
+.new_schedule_input_label {
     padding: 4px 0px 0px 11px;
 }
 
-#scheduleTextAndButtonContainer {
+.input_and_buttons_container {
     display: flex;
-    flex-direction: row;
+    padding: 12px 15px 15px 11px;
 }
 
-input {
+#new_schedule_input {
     height: 25px;
-    margin: 12px 20px 15px 11px;
     flex: auto;
     background: #F5F5F5;
+    margin-right: 20px;
 }
 
-.btnAddOrCancel {
+.new_schedule_input_button_container {
+    display: flex;
+}
+
+.new_schedule_input_button {
     box-sizing: border-box;
-    margin: 12px 0px 15px 0px;
-    padding: 4px 12px 2px 13px;
+    width: 55px;
     background: #2C2C2C;
     border: 1px solid #FFFFFF;
     border-radius: 5px;
 }
 
-#addBtn {
+#add_input_button {
     margin-right: 5px;
 }
 
-#cancelBtn {
-    margin-right: 15px;
-}
-
 .no_schedule_span {
-    font-family: 'Inter';
-    font-style: normal;
     font-weight: 700;
     font-size: 24px;
     line-height: 29px;

--- a/style.css
+++ b/style.css
@@ -16,16 +16,6 @@ header {
     justify-content: space-between;
     flex-direction: column;
 }
-/*
-span {
-    font-family: 'Inter';
-    font-style: normal;
-    font-weight: 500;
-    font-size: 16px;
-    line-height: 19px;
-    color: #000000;
-}
-*/
 
 #container {
     flex: 1;
@@ -34,7 +24,7 @@ span {
     justify-content: center;
 }
 
-.white_text {
+span {
     font-family: 'Inter';
     font-style: normal;
     text-align: center;
@@ -60,20 +50,6 @@ span {
     position: absolute;
     top: -2px;
     right: 12px;
-}
-
-.plus_button {
-    /*
-    width: 27px;
-    height: 27px;
-    border: 1px solid #FFFFFF;
-    
-    border-radius: 50%;
-    background-color: #2C2C2C;
-    position: absolute;
-    top: 9px;
-    right: 11px;
-    */
 }
 
 .top_container {

--- a/style.css
+++ b/style.css
@@ -47,7 +47,7 @@ span {
     font-weight: 300;
     font-size: 36px;
     line-height: 44px;
-    position: absolute;
+    position: fixed;
     top: -2px;
     right: 12px;
 }
@@ -64,14 +64,14 @@ span {
     line-height: 19px;
 }
 
-#btnPlus {
+.plus_button {
     width: 27px;
     height: 27px;
     border: 1px solid #FFFFFF;
     /* float: right; */
     border-radius: 50%;
     background-color: transparent;
-    position: absolute;
+    position: fixed;
     top: 9px;
     right: 11px;
 }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,6 @@
 body {
     margin: 0px;
     height: 100vh;
-
     display: flex;
     flex-direction: column;
     overflow-x: hidden;
@@ -12,7 +11,6 @@ header {
     height: 46px;
     box-sizing: border-box;
     padding: 9px 15px 8px 11px;
-
     background: #2C2C2C;
 }
 /*
@@ -22,7 +20,6 @@ span {
     font-weight: 500;
     font-size: 16px;
     line-height: 19px;
-
     color: #000000;
 }
 */
@@ -62,13 +59,6 @@ span {
     float: right;
     padding-bottom: 10px;
     border-radius: 50%;
-
-    font-family: 'Inter';
-    font-style: normal;
-    font-weight: 300;
-    font-size: 2.5em;
-
-    color: #FFFFFF;
     background-color: #2C2C2C;
     border-color: #FFFFFF;
 }
@@ -77,7 +67,6 @@ span {
     width: 100%;
     height: 75px;
     display: none;
-
     background: #2C2C2C;
 }
 
@@ -94,7 +83,6 @@ input {
     height: 25px;
     margin: 12px 20px 15px 11px;
     flex: auto;
-
     background: #F5F5F5;
 }
 
@@ -102,7 +90,6 @@ input {
     box-sizing: border-box;
     margin: 12px 0px 15px 0px;
     padding: 4px 12px 2px 13px;
-
     background: #2C2C2C;
     border: 1px solid #FFFFFF;
     border-radius: 5px;

--- a/style.css
+++ b/style.css
@@ -8,10 +8,12 @@ body {
 
 header {
     width: 100vw;
-    height: 46px;
+    min-height: 46px;
     box-sizing: border-box;
-    padding: 9px 15px 8px 11px;
+    /* padding: 9px 15px 8px 11px; */
     background: #2C2C2C;
+    display: flex;
+    justify-content: space-between;
 }
 /*
 span {
@@ -31,36 +33,55 @@ span {
     justify-content: center;
 }
 
-.white_bold_text {
+.white_text {
     font-family: 'Inter';
     font-style: normal;
-    font-weight: 700;
-    font-size: 24px;
-    line-height: 29px;
     text-align: center;
     color: #FFFFFF;
 }
 
-.white_small_text {
-    font-family: 'Inter';
-    font-style: normal;
+.logo {
+    display: inline-block;
+    font-weight: 700;
+    font-size: 24px;
+    line-height: 29px;
+    height: calc(100% - 18px);
+}
+
+.logo {
+    margin: 9px 15px;
+}
+
+.plus_span {
+    font-weight: 300;
+    font-size: 36px;
+    line-height: 44px;
+    position: absolute;
+    top: -2px;
+    right: 12px;
+}
+
+.plus_button {
+    width: 27px;
+    height: 27px;
+    border: 1px solid #FFFFFF;
+    /* float: right; */
+    border-radius: 50%;
+    background-color: #2C2C2C;
+    position: absolute;
+    top: 9px;
+    right: 11px;
+}
+
+.new_schedule_input_label, .btnAddOrCancel {
     font-weight: 500;
     font-size: 16px;
     line-height: 19px;
-    color: #FFFFFF;
 }
 
 #btnPlus {
-    width: 27px;
-    height: 27px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    float: right;
-    padding-bottom: 10px;
-    border-radius: 50%;
     background-color: #2C2C2C;
-    border-color: #FFFFFF;
+    border: none;
 }
 
 #addScheduleContainer {

--- a/style.css
+++ b/style.css
@@ -103,6 +103,25 @@ span {
     margin-right: 5px;
 }
 
+main {
+    flex: 1;
+    display: flex;
+}
+
+#no_schedule_container {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#schedule_list_container {
+    flex: 0;
+    display: flex;
+    justify-content: flex-start;
+    flex-direction: column;
+}
+
 .no_schedule_span {
     font-weight: 700;
     font-size: 24px;

--- a/style.css
+++ b/style.css
@@ -14,6 +14,7 @@ header {
     background: #2C2C2C;
     display: flex;
     justify-content: space-between;
+    flex-direction: column;
 }
 /*
 span {
@@ -62,15 +63,23 @@ span {
 }
 
 .plus_button {
+    /*
     width: 27px;
     height: 27px;
     border: 1px solid #FFFFFF;
-    /* float: right; */
+    
     border-radius: 50%;
     background-color: #2C2C2C;
     position: absolute;
     top: 9px;
     right: 11px;
+    */
+}
+
+.top_container {
+    width: 100%;
+    max-height: 46px;
+    display: block;
 }
 
 .new_schedule_input_label, .btnAddOrCancel {
@@ -80,8 +89,15 @@ span {
 }
 
 #btnPlus {
-    background-color: #2C2C2C;
-    border: none;
+    width: 27px;
+    height: 27px;
+    border: 1px solid #FFFFFF;
+    /* float: right; */
+    border-radius: 50%;
+    background-color: transparent;
+    position: absolute;
+    top: 9px;
+    right: 11px;
 }
 
 #addScheduleContainer {

--- a/style.css
+++ b/style.css
@@ -1,0 +1,134 @@
+body {
+    margin: 0px;
+    height: 100vh;
+
+    display: flex;
+    flex-direction: column;
+    overflow-x: hidden;
+}
+
+header {
+    width: 100vw;
+    height: 46px;
+    box-sizing: border-box;
+    padding: 9px 15px 8px 11px;
+
+    background: #2C2C2C;
+}
+
+span {
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 19px;
+
+    color: #000000;
+}
+
+#container {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#title {
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 700;
+    font-size: 24px;
+    line-height: 29px;
+    text-align: center;
+
+    color: #FFFFFF;
+}
+
+#btnPlus {
+    width: 27px;
+    height: 27px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    float: right;
+    padding-bottom: 10px;
+    border-radius: 50%;
+
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 300;
+    font-size: 2.5em;
+
+    color: #FFFFFF;
+    background-color: #2C2C2C;
+    border-color: #FFFFFF;
+}
+
+#addScheduleContainer {
+    width: 100%;
+    height: 75px;
+    display: none;
+
+    background: #2C2C2C;
+}
+
+#addTitle {
+    display: block;
+    padding: 4px 0px 0px 11px;
+
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 19px;
+
+    color: #FFFFFF;
+}
+
+#scheduleTextAndButtonContainer {
+    display: flex;
+    flex-direction: row;
+}
+
+input {
+    height: 25px;
+    margin: 12px 20px 15px 11px;
+    flex: auto;
+
+    background: #F5F5F5;
+}
+
+.btnAddOrCancel {
+    box-sizing: border-box;
+    margin: 12px 0px 15px 0px;
+    padding: 4px 12px 2px 13px;
+
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 19px;
+
+    background: #2C2C2C;
+    color: #FFFFFF;
+    border: 1px solid #FFFFFF;
+    border-radius: 5px;
+}
+
+#addBtn {
+    margin-right: 5px;
+}
+
+#cancelBtn {
+    margin-right: 15px;
+}
+
+#noScheduleMessage {
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 700;
+    font-size: 24px;
+    line-height: 29px;
+
+    color: #C2C2C2;
+}

--- a/style.css
+++ b/style.css
@@ -47,7 +47,7 @@ span {
     right: 12px;
 }
 
-.plus_button {
+#plus_button {
     width: 27px;
     height: 27px;
     border: 1px solid #FFFFFF;

--- a/style.css
+++ b/style.css
@@ -65,7 +65,8 @@ span {
     background: #2C2C2C;
 }
 
-.new_schedule_input_label, .new_schedule_input_button {
+.new_schedule_input_label,
+.new_schedule_input_button {
     font-weight: 500;
     font-size: 16px;
     line-height: 19px;
@@ -127,4 +128,34 @@ main {
     font-size: 24px;
     line-height: 29px;
     color: #C2C2C2;
+}
+
+ul {
+    margin: 0;
+    padding: 0;
+}
+
+li {
+    width: 100vw;
+    padding: 24px 17px 24px 11px;
+    border-bottom: 1px solid #DEDEDE;
+    box-sizing: border-box;
+    list-style: none;
+    display: flex;
+    justify-content: space-between;
+}
+
+li>button {
+    border: none;
+    background-color: transparent;
+    padding: 0;
+}
+
+li>span, li>button {
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 19px;
+    color: #000000;
 }

--- a/style.css
+++ b/style.css
@@ -15,7 +15,7 @@ header {
 
     background: #2C2C2C;
 }
-
+/*
 span {
     font-family: 'Inter';
     font-style: normal;
@@ -25,6 +25,7 @@ span {
 
     color: #000000;
 }
+*/
 
 #container {
     flex: 1;
@@ -33,14 +34,22 @@ span {
     justify-content: center;
 }
 
-#title {
+.white_bold_text {
     font-family: 'Inter';
     font-style: normal;
     font-weight: 700;
     font-size: 24px;
     line-height: 29px;
     text-align: center;
+    color: #FFFFFF;
+}
 
+.white_small_text {
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 19px;
     color: #FFFFFF;
 }
 
@@ -74,14 +83,6 @@ span {
 
 label {
     padding: 4px 0px 0px 11px;
-
-    font-family: 'Inter';
-    font-style: normal;
-    font-weight: 500;
-    font-size: 16px;
-    line-height: 19px;
-
-    color: #FFFFFF;
 }
 
 #scheduleTextAndButtonContainer {
@@ -102,14 +103,7 @@ input {
     margin: 12px 0px 15px 0px;
     padding: 4px 12px 2px 13px;
 
-    font-family: 'Inter';
-    font-style: normal;
-    font-weight: 500;
-    font-size: 16px;
-    line-height: 19px;
-
     background: #2C2C2C;
-    color: #FFFFFF;
     border: 1px solid #FFFFFF;
     border-radius: 5px;
 }
@@ -122,12 +116,11 @@ input {
     margin-right: 15px;
 }
 
-#noScheduleMessage {
+.no_schedule_span {
     font-family: 'Inter';
     font-style: normal;
     font-weight: 700;
     font-size: 24px;
     line-height: 29px;
-
     color: #C2C2C2;
 }


### PR DESCRIPTION
[구현]
-일정 추가/삭제
: 스케줄 배열을 만들어 관리 

-+ -> 일정 추가 영역 show
-추가/취소 버튼 -> 일정 추가 영역 hide
: show/hideContents 함수에 해당 상수화된 content 이름을 매개변수로 넣어 해당 content일 때 content의 style 변경

-일정 없으면 "남은 일정이 없어요"
: changeContainerStyle 함수를 만들어 배열에 스케줄이 있을 때/없을 때를 기준으로 container style 변경 + show/hide content

[질문]
-스크롤 자동 활성화
❓ 별도의 코드 없이 스크롤이 자동으로 생겼습니다. 이유가 뭔지 모르겠습니다.

-btnPlus
![image](https://user-images.githubusercontent.com/83866983/214574348-4a3193c3-b588-4aa7-944c-454f399ab536.png)
: btnPlus에서 display flex와 align 속성을 적용하지 않으면 위 사진처럼 버튼 텍스트가 버튼 테두리를 한참 벗어나게 생깁니다. 왜 이런 문제가 생길까요? +) 버튼 테두리가 두 가지 색이 섞여서 나타나는 이유는 뭔가요?

[help wanted]
-스크롤
: 스크롤이 자동으로 생기면 우측에 세로 스크롤만큼의 영역을 잡아먹게 되면서 가로 스크롤까지 생겼습니다. -> 가로 스크롤을 hide하여 가려둔 상태인데, 이 방법 말고 스크롤이 생기면 스크롤만큼의 영역을 뺀 부분을 전체 영역으로 인식하도록 할 수는 없을까요?

-js에서 style 변경
❓ js file에서 style을 변경하는 코드를 추가하면 ex. addScheduleContainer.style.display = 'block';
![image](https://user-images.githubusercontent.com/83866983/214571480-5da28620-6a61-43f3-a128-b8391b70a5ed.png)
사진처럼 html에 inline으로 style 코드가 추가됩니다. css file에서 변경되게 하는 방법은 없을까요?

-flex align
: 처음 container의 flex style은 남은 일정이 없어요 라는 메시지를 중앙배열하기 위해 
`container.style.flexDirection = "row"
        container.style.alignItems = "center";
        container.style.justifyContent = "center";` 
상태로 설정하였고, 스케줄이 추가되면 
`container.style.flexDirection = "column"
        container.style.alignItems = "flex-start";
        container.style.justifyContent = "flex-start";`
로 style이 바뀌도록 설정하였습니다. -> 이렇게 제어하는 것이 번거롭게 느껴져서 다른 방법은 없을지 질문드리고 싶습니다.

-flex 중복 사용
: body의 남은 부분을 container의 영역으로 주기 위해 body의 display를 flex로 사용하고, 이를 통해 제어되는 element 중 하나가 container가 되도록 설정하였습니다. 또 container에서 메시지를 중앙 정렬하거나 스케줄을 start로 정렬시키기 위해서 container의 display를 flex로 지정하게 되었습니다. 이처럼 flex를 중복사용해도 되나요? 아니면 전체적인 element 하나에(ex. body) display를 flex로 지정하고 그 안에 들어있는 element들을 각기 다른 방법으로 정렬시키는 방법을 사용할 수 있나요?